### PR TITLE
Feature/086 related products

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@mdi/js": "^7.4.47",
         "clsx": "^2.1.1",
         "eslint-config-prettier": "^10.0.2",
+        "nanoid": "^5.1.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.2.0"
@@ -4014,10 +4015,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
-      "dev": true,
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.2.tgz",
+      "integrity": "sha512-b+CiXQCNMUGe0Ri64S9SXFcP9hogjAJ2Rd6GdVxhPLRm7mhGaM7VgOvCAJ1ZshfHbqVDI3uqTI5C8/GaKuLI7g==",
       "funding": [
         {
           "type": "github",
@@ -4026,10 +4026,10 @@
       ],
       "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/natural-compare": {
@@ -4514,6 +4514,25 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@mdi/js": "^7.4.47",
     "clsx": "^2.1.1",
     "eslint-config-prettier": "^10.0.2",
+    "nanoid": "^5.1.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.2.0"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ function App() {
       <Layout>
         <Routes>
           <Route path="/" element={<Homepage />} />
-          <Route path="/Detailpage" element={<Detailpage />} />
+          <Route path="/detailpage" element={<Detailpage />} />
         </Routes>
       </Layout>
     </Router>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Layout from "./components/Layout.tsx";
 import Homepage from "./pages/Homepage.tsx";
+import { Related } from "./utils";
 
 function App() {
   return (
@@ -8,6 +9,7 @@ function App() {
       <Layout>
         <Routes>
           <Route path="/" element={<Homepage />} />
+          <Route path="/Detailpage" element={<Related />} />
         </Routes>
       </Layout>
     </Router>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Layout from "./components/Layout.tsx";
 import Homepage from "./pages/Homepage.tsx";
-import { Related } from "./utils";
+import Detailpage from "./pages/Detailpage.tsx";
 
 function App() {
   return (
@@ -9,7 +9,7 @@ function App() {
       <Layout>
         <Routes>
           <Route path="/" element={<Homepage />} />
-          <Route path="/Detailpage" element={<Related />} />
+          <Route path="/Detailpage" element={<Detailpage />} />
         </Routes>
       </Layout>
     </Router>

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -42,8 +42,8 @@ export default function ProductCard({
   className = "",
   ...restProps
 }: Props) {
-  const truncatedDescription = truncateText(description, 20);
-  const truncatedName = truncateText(name, 10);
+  const truncatedDescription = truncateText(description, 25);
+  const truncatedName = truncateText(name, 20);
 
   return (
     <div

--- a/src/components/RelatedProducts.tsx
+++ b/src/components/RelatedProducts.tsx
@@ -18,7 +18,7 @@ const RelatedProduct = () => {
         <Heading as="h2" size="text2xl">
           Related Products
         </Heading>
-        <ul className={styles.relatedProducts} title="Related Products">
+        <ul className={styles.relatedProducts}>
           <li>
             <ProductCard {...dummy} />
           </li>

--- a/src/components/RelatedProducts.tsx
+++ b/src/components/RelatedProducts.tsx
@@ -1,10 +1,11 @@
 import { Heading, Button } from "../utils";
+import styles from "../scss/components/RelatedProducts.module.scss";
 
 const RelatedProduct = () => {
   return (
-    <div>
-      <div>
-        <Heading as="h2" className="title">
+    <div className={styles.container}>
+      <div className={styles.internalContainer}>
+        <Heading as="h2" size="text2xl">
           Related Products
         </Heading>
         <div>Products</div>

--- a/src/components/RelatedProducts.tsx
+++ b/src/components/RelatedProducts.tsx
@@ -1,10 +1,14 @@
-import { Heading } from "../utils";
+import { Heading, Button } from "../utils";
 
 const RelatedProduct = () => {
   return (
     <div>
       <div>
-        <Heading>Related Products</Heading>
+        <Heading as="h2" className="title">
+          Related Products
+        </Heading>
+        <div>Products</div>
+        <Button className="button">Show More</Button>
       </div>
     </div>
   );

--- a/src/components/RelatedProducts.tsx
+++ b/src/components/RelatedProducts.tsx
@@ -1,0 +1,13 @@
+import { Heading } from "../utils";
+
+const RelatedProduct = () => {
+  return (
+    <div>
+      <div>
+        <Heading>Related Products</Heading>
+      </div>
+    </div>
+  );
+};
+
+export default RelatedProduct;

--- a/src/components/RelatedProducts.tsx
+++ b/src/components/RelatedProducts.tsx
@@ -8,8 +8,29 @@ const RelatedProduct = () => {
         <Heading as="h2" size="text2xl">
           Related Products
         </Heading>
-        <div>Products</div>
-        <Button className="button">Show More</Button>
+        <div className={styles.relatedProducts}>
+          <div>
+            <img src="https://picsum.photos/150" alt="related product" />
+            <p>Product Name</p>
+            <p>$100</p>
+          </div>
+          <div>
+            <img src="https://picsum.photos/150" alt="related product" />
+            <p>Product Name</p>
+            <p>$100</p>
+          </div>
+          <div>
+            <img src="https://picsum.photos/150" alt="related product" />
+            <p>Product Name</p>
+            <p>$100</p>
+          </div>
+          <div>
+            <img src="https://picsum.photos/150" alt="related product" />
+            <p>Product Name</p>
+            <p>$100</p>
+          </div>
+        </div>
+        <Button className={styles.showBtn}>Show More</Button>
       </div>
     </div>
   );

--- a/src/components/RelatedProducts.tsx
+++ b/src/components/RelatedProducts.tsx
@@ -5,7 +5,7 @@ const RelatedProduct = () => {
   const dummy = {
     id: "1",
     name: "Example Product",
-    description: "Product description",
+    description: "This is an example product description",
     image: poke,
     price: 29.99,
     currentPrice: "$29.99",
@@ -14,18 +14,26 @@ const RelatedProduct = () => {
 
   return (
     <div className={styles.container}>
-      <div className={styles.internalContainer}>
+      <section className={styles.internalContainer} title="Related Products">
         <Heading as="h2" size="text2xl">
           Related Products
         </Heading>
-        <div className={styles.relatedProducts}>
-          <ProductCard {...dummy} />
-          <ProductCard {...dummy} />
-          <ProductCard {...dummy} />
-          <ProductCard {...dummy} />
-        </div>
+        <ul className={styles.relatedProducts} title="Related Products">
+          <li>
+            <ProductCard {...dummy} />
+          </li>
+          <li>
+            <ProductCard {...dummy} />
+          </li>
+          <li>
+            <ProductCard {...dummy} />
+          </li>
+          <li>
+            <ProductCard {...dummy} />
+          </li>
+        </ul>
         <Button className={styles.showBtn}>Show More</Button>
-      </div>
+      </section>
     </div>
   );
 };

--- a/src/components/RelatedProducts.tsx
+++ b/src/components/RelatedProducts.tsx
@@ -1,7 +1,17 @@
-import { Heading, Button } from "../utils";
+import { Heading, Button, ProductCard } from "../utils";
 import styles from "../scss/components/RelatedProducts.module.scss";
-
+import poke from "../assets/poke.png";
 const RelatedProduct = () => {
+  const dummy = {
+    id: "1",
+    name: "Example Product",
+    description: "Product description",
+    image: poke,
+    price: 29.99,
+    currentPrice: "$29.99",
+    originalPrice: "$39.99",
+  };
+
   return (
     <div className={styles.container}>
       <div className={styles.internalContainer}>
@@ -9,26 +19,10 @@ const RelatedProduct = () => {
           Related Products
         </Heading>
         <div className={styles.relatedProducts}>
-          <div>
-            <img src="https://picsum.photos/150" alt="related product" />
-            <p>Product Name</p>
-            <p>$100</p>
-          </div>
-          <div>
-            <img src="https://picsum.photos/150" alt="related product" />
-            <p>Product Name</p>
-            <p>$100</p>
-          </div>
-          <div>
-            <img src="https://picsum.photos/150" alt="related product" />
-            <p>Product Name</p>
-            <p>$100</p>
-          </div>
-          <div>
-            <img src="https://picsum.photos/150" alt="related product" />
-            <p>Product Name</p>
-            <p>$100</p>
-          </div>
+          <ProductCard {...dummy} />
+          <ProductCard {...dummy} />
+          <ProductCard {...dummy} />
+          <ProductCard {...dummy} />
         </div>
         <Button className={styles.showBtn}>Show More</Button>
       </div>

--- a/src/pages/Detailpage.tsx
+++ b/src/pages/Detailpage.tsx
@@ -1,0 +1,10 @@
+import { Related } from "../utils/index.ts";
+
+const Detailpage = () => {
+  return (
+    <>
+      <Related />
+    </>
+  );
+};
+export default Detailpage;

--- a/src/scss/abstracts/typography.module.scss
+++ b/src/scss/abstracts/typography.module.scss
@@ -22,6 +22,7 @@
   }
 
   &-2xl {
+    font-size: 3.6rem;
   }
 
   &-3xl {

--- a/src/scss/components/Loading.module.scss
+++ b/src/scss/components/Loading.module.scss
@@ -7,11 +7,11 @@
   min-width: 28.5rem;
 
   @media (max-width: $breakpoint-md) {
-    min-width: 30.2rem;
+    min-width: 29rem;
   }
 
   @media (max-width: $breakpoint-sm) {
-    min-width: 30.4rem;
+    min-width: 30rem;
   }
 
   .imageWrapper {

--- a/src/scss/components/ProductCard.module.scss
+++ b/src/scss/components/ProductCard.module.scss
@@ -9,10 +9,10 @@
   position: relative;
 
   @media (max-width: $breakpoint-md) {
-    min-width: 320px;
+    min-width: 290px;
   }
   @media (max-width: $breakpoint-sm) {
-    min-width: 340px;
+    min-width: 300px;
   }
   .imageWrapper {
     position: relative;

--- a/src/scss/components/RelatedProducts.module.scss
+++ b/src/scss/components/RelatedProducts.module.scss
@@ -1,9 +1,6 @@
 @use "../abstracts/typography.module.scss" as *;
 @use "../partials/variables" as *;
 
-$md: 768px;
-$sm: 640px;
-
 .container {
   margin-bottom: 3.6rem;
   display: flex;
@@ -20,12 +17,51 @@ $sm: 640px;
     font-weight: $font-weight-medium;
   }
 
-  @media (max-width: $md) {
+  @media (max-width: $breakpoint-md) {
     padding-left: 2rem;
     padding-right: 2rem;
 
     h2 {
       font-size: 2.5rem;
+    }
+  }
+
+  @media (max-width: $breakpoint-sm) {
+    h2 {
+      font-size: 2rem;
+    }
+  }
+
+  .relatedProducts {
+    margin-top: 2.6rem;
+    display: flex;
+    gap: 3.2rem;
+    width: 100%;
+    align-items: center;
+
+    @media (max-width: $breakpoint-md) {
+      flex-direction: column;
+    }
+  }
+  .showBtn {
+    margin-top: 4.4rem;
+    min-width: 24.5rem;
+    min-height: 4.8rem;
+    border: 1px solid var(--basic-blue);
+    background-color: var(--white);
+    color: var(--basic-blue);
+    font-weight: $font-weight-semi-bold;
+    text-align: center;
+    cursor: pointer;
+    transition: all 0.3s;
+    &:hover {
+      background-color: var(--basic-blue);
+      color: var(--white);
+    }
+
+    @media (max-width: $breakpoint-sm) {
+      padding-left: 2rem;
+      padding-right: 2rem;
     }
   }
 }

--- a/src/scss/components/RelatedProducts.module.scss
+++ b/src/scss/components/RelatedProducts.module.scss
@@ -1,0 +1,31 @@
+@use "../abstracts/typography.module.scss" as *;
+@use "../partials/variables" as *;
+
+$md: 768px;
+$sm: 640px;
+
+.container {
+  margin-bottom: 3.6rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  .internalContainer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  h2 {
+    font-weight: $font-weight-medium;
+  }
+
+  @media (max-width: $md) {
+    padding-left: 2rem;
+    padding-right: 2rem;
+
+    h2 {
+      font-size: 2.5rem;
+    }
+  }
+}

--- a/src/scss/components/RelatedProducts.module.scss
+++ b/src/scss/components/RelatedProducts.module.scss
@@ -34,13 +34,16 @@
 
   .relatedProducts {
     margin-top: 2.6rem;
-    display: flex;
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
     gap: 3.2rem;
-    width: 100%;
-    align-items: center;
+    width: auto;
+    @media (max-width: $breakpoint) {
+      grid-template-columns: repeat(2, 1fr);
+    }
 
-    @media (max-width: $breakpoint-md) {
-      flex-direction: column;
+    @media (max-width: $breakpoint-sm) {
+      grid-template-columns: 1fr;
     }
   }
   .showBtn {

--- a/src/scss/components/RelatedProducts.module.scss
+++ b/src/scss/components/RelatedProducts.module.scss
@@ -2,7 +2,8 @@
 @use "../partials/variables" as *;
 
 .container {
-  margin-bottom: 3.6rem;
+  margin-bottom: 7rem;
+  margin-top: 5rem;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -21,7 +21,7 @@ export { default as Related } from "../components/RelatedProducts.tsx";
 export const headerLinks = {
   navLinks: [
     { path: "/", label: "Home" },
-    { path: "/", label: "Shop" },
+    { path: "/Shop", label: "Shop" },
     { path: "/about", label: "About" },
     { path: "/contact", label: "Contact" },
   ],

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -14,6 +14,7 @@ export { default as UspBanner } from "../components/UspBanner.tsx";
 export { default as BannerShop } from "../components/BannerShop.tsx";
 export { default as FilterSortBar } from "../components/FilterSortBar.tsx";
 export { default as Pagination } from "../components/Pagination.tsx";
+export { default as Related } from "../components/RelatedProducts.tsx";
 
 // I think putting the links here is a good idea, it makes it easier to manage and update as needed
 // Header links

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -21,7 +21,7 @@ export { default as Related } from "../components/RelatedProducts.tsx";
 export const headerLinks = {
   navLinks: [
     { path: "/", label: "Home" },
-    { path: "/Shop", label: "Shop" },
+    { path: "/shop", label: "Shop" },
     { path: "/about", label: "About" },
     { path: "/contact", label: "Contact" },
   ],


### PR DESCRIPTION
Implement the basic structure and styling for the RelatedProduct component, this includes adding a heading, rendering four ProductCard components with dummy data, and including a "Show More" button, this task is for styling and layout only functionality will be handled separately.
The component can be viewed by navigating to `/detailpage`.

![Screenshot 2025-03-03 041010](https://github.com/user-attachments/assets/3010f952-93fd-4458-a134-bb2eb3deea1f)
