### PR TITLE
add API_URL env variable to github vercel actions

### DIFF
--- a/.github/workflows/ci_vercel_deploy.yml
+++ b/.github/workflows/ci_vercel_deploy.yml
@@ -9,9 +9,21 @@ jobs:
   build_and_deploy:
     name: Build & Deploy
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Set ENV variables
+        uses: dkershner6/vercel-set-env-action@v3
+        with:
+          token: ${{ secrets.VERCEL_TOKEN }}
+          projectName: poke-markt-webshop
+          envVariableKeys: VITE_API_URL
+        env:
+          VITE_API_URL: ${{ env.VITE_API_URL }}
+          TARGET_VITE_API_URL: production
+          TYPE_VITE_API_URL: plain
 
       - name: Build & Deploy on Vercel
         uses: amondnet/vercel-action@v25

--- a/.github/workflows/ci_vercel_deploy.yml
+++ b/.github/workflows/ci_vercel_deploy.yml
@@ -21,7 +21,7 @@ jobs:
           projectName: poke-markt-webshop
           envVariableKeys: VITE_API_URL
         env:
-          VITE_API_URL: ${{ env.VITE_API_URL }}
+          VITE_API_URL: ${{ vars.VITE_API_URL }}
           TARGET_VITE_API_URL: production
           TYPE_VITE_API_URL: plain
 

--- a/.github/workflows/ci_vercel_preview.yml
+++ b/.github/workflows/ci_vercel_preview.yml
@@ -26,7 +26,7 @@ jobs:
           projectName: poke-markt-webshop
           envVariableKeys: VITE_API_URL
         env:
-          VITE_API_URL: ${{ env.VITE_API_URL }}
+          VITE_API_URL: ${{ vars.VITE_API_URL }}
           TARGET_VITE_API_URL: preview
           TYPE_VITE_API_URL: plain
 

--- a/.github/workflows/ci_vercel_preview.yml
+++ b/.github/workflows/ci_vercel_preview.yml
@@ -10,6 +10,7 @@ jobs:
   build_and_deploy:
     name: Build & Preview
     runs-on: ubuntu-latest
+    environment: preview
     permissions:
       contents: write
       pull-requests: write
@@ -17,6 +18,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Set ENV variables
+        uses: dkershner6/vercel-set-env-action@v3
+        with:
+          token: ${{ secrets.VERCEL_TOKEN }}
+          projectName: poke-markt-webshop
+          envVariableKeys: VITE_API_URL
+        env:
+          VITE_API_URL: ${{ env.VITE_API_URL }}
+          TARGET_VITE_API_URL: preview
+          TYPE_VITE_API_URL: plain
 
       - name: Build & Generate Preview on Vercel
         uses: amondnet/vercel-action@v25

--- a/src/components/home/ProductGrid.tsx
+++ b/src/components/home/ProductGrid.tsx
@@ -21,7 +21,7 @@ const ProductGrid = ({ data: initialData = [] }: ShopGridProps) => {
     const fetchData = async () => {
       try {
         const response = await fetch(
-          `${import.meta.env.VITE_API_URL}/items?page=${currentPage}`,
+          `${import.meta.env.VITE_API_URL}/api/items?page=${currentPage}`,
         );
         if (!response.ok) throw new Error("Failed to fetch data");
         const result = (await response.json()) as ApiResponse;

--- a/src/services/productService.ts
+++ b/src/services/productService.ts
@@ -1,6 +1,6 @@
 import { Product, ApiListResponse, ApiSingleResponse } from "../types/types";
 
-const API_BASE_URL: string = import.meta.env.VITE_API_URL;
+const API_BASE_URL: string = import.meta.env.VITE_API_URL + "/api";
 
 export const productService = {
   async getRecommendations(limit: number = 5): Promise<Product[]> {

--- a/src/store/pokemartApi.ts
+++ b/src/store/pokemartApi.ts
@@ -5,7 +5,7 @@ import { apiResponse } from "../types/apiTypes/response";
 const pokemartApi = createApi({
   reducerPath: "pokemartApi",
   baseQuery: fetchBaseQuery({
-    baseUrl: import.meta.env.VITE_API_URL,
+    baseUrl: import.meta.env.VITE_API_URL + "/api",
     responseHandler: async (response) => {
       const data = (await response.json()) as apiResponse;
       return data.data;


### PR DESCRIPTION
env variables added to github enviorment the action looks up the env var from the relevant enviorment 

3 new enviorments on the repo
- development
- preview
- production

development & production use: `VITE_API_URL = https://poke-market-1067439832688.us-central1.run.app`
production uses: `VITE_API_URL = https://poke-mart-252498914455.us-central1.run.app`

### /api
note that I dropped the `/api` part. I have updated the code to append `/api` where we used it previously.
The Reason I did this is because there might be cases where we don't want to appand api, like when referencing to the admin dashboard. 

### secrets vs vars
the env variables are under repo vars instead of secrets and not encrypted because I didn't think this was critical data.
This makes it also easier to edit/see their current setting

You can check them out here: [settings/enviorments](https://github.com/Poke-market/poke_markt_webshop/settings/environments)
*(select an environment and scroll to the bottom)*